### PR TITLE
Split verify and vote

### DIFF
--- a/NftVotePlugin/accounts.ts
+++ b/NftVotePlugin/accounts.ts
@@ -43,7 +43,7 @@ export const getUsedNftWeightRecordsForOwner = async (
     [
       {
         memcmp: {
-          offset: 0,
+          offset: 8,
           bytes: owner.toBase58(),
         },
       },
@@ -83,8 +83,8 @@ export const getNftWeightRecordProgramAddress = async (
   ] = await PublicKey.findProgramAddress(
     [
       Buffer.from('nft-weight-record'),
-      new PublicKey(nftMintAddress).toBuffer(),
       owner.toBuffer(),
+      new PublicKey(nftMintAddress).toBuffer(),
     ],
     clientProgramId
   )

--- a/NftVotePlugin/accounts.ts
+++ b/NftVotePlugin/accounts.ts
@@ -35,7 +35,7 @@ export const getUsedNftsForProposal = async (
   return nftVoteRecordsFiltered
 }
 
-export const getVoterNftVoteTicketsForRegistrar = async (
+export const getNftVoteTicketsForRegistrar = async (
   client: NftVoterClient,
   registrar: PublicKey
 ) => {
@@ -73,13 +73,14 @@ export const getNftVoteRecordProgramAddress = async (
 }
 
 export const getNftVoteTicketProgramAddress = async (
-  nftMintAddress: string,
+  ticketType: string,
   registrar: PublicKey,
+  nftMintAddress: string,
   clientProgramId: PublicKey
 ) => {
   const [nftVoteTicket, nftVoteTicketBump] = await PublicKey.findProgramAddress(
     [
-      Buffer.from('nft-weight-record'),
+      Buffer.from(ticketType),
       registrar.toBuffer(),
       new PublicKey(nftMintAddress).toBuffer(),
     ],

--- a/NftVotePlugin/accounts.ts
+++ b/NftVotePlugin/accounts.ts
@@ -45,3 +45,19 @@ export const getNftVoteRecordProgramAddress = async (
     nftVoteRecordBump,
   }
 }
+
+export const getNftWeightRecordProgramAddress = async (
+  nftMintAddress: string,
+  clientProgramId: PublicKey
+) => {
+  const [nftWeightRecord, nftWeightRecordBump] =
+    await PublicKey.findProgramAddress(
+      [Buffer.from('nft-weight-record'), new PublicKey(nftMintAddress).toBuffer()],
+      clientProgramId
+    )
+
+  return {
+    nftWeightRecord,
+    nftWeightRecordBump,
+  }
+}

--- a/NftVotePlugin/accounts.ts
+++ b/NftVotePlugin/accounts.ts
@@ -35,11 +35,20 @@ export const getUsedNftsForProposal = async (
   return nftVoteRecordsFiltered
 }
 
-export const getUsedNftWeightRecordsForUser = async (
-  client: NftVoterClient
-  //walletPk: PublicKey
+export const getUsedNftWeightRecordsForOwner = async (
+  client: NftVoterClient,
+  owner: PublicKey
 ) => {
-  const nftWeightRecordsFiltered = ((await client.program.account.nftWeightRecord.all()) as unknown) as NftWeightRecord[]
+  const nftWeightRecordsFiltered = ((await client.program.account.nftWeightRecord.all(
+    [
+      {
+        memcmp: {
+          offset: 8,
+          bytes: owner.toBase58(),
+        },
+      },
+    ]
+  )) as unknown) as NftWeightRecord[]
   return nftWeightRecordsFiltered
 }
 
@@ -65,6 +74,7 @@ export const getNftVoteRecordProgramAddress = async (
 
 export const getNftWeightRecordProgramAddress = async (
   nftMintAddress: string,
+  owner: PublicKey,
   clientProgramId: PublicKey
 ) => {
   const [
@@ -73,6 +83,7 @@ export const getNftWeightRecordProgramAddress = async (
   ] = await PublicKey.findProgramAddress(
     [
       Buffer.from('nft-weight-record'),
+      owner.toBuffer(),
       new PublicKey(nftMintAddress).toBuffer(),
     ],
     clientProgramId

--- a/NftVotePlugin/accounts.ts
+++ b/NftVotePlugin/accounts.ts
@@ -1,10 +1,19 @@
 import { NftVoterClient } from '@utils/uiTypes/NftVoterClient'
 import { PublicKey } from '@solana/web3.js'
+import { BN } from '@coral-xyz/anchor'
 export interface NftVoteRecord {
   account: {
     governingTokenOwner: PublicKey
     nftMint: PublicKey
     proposal: PublicKey
+  }
+  publicKey: PublicKey
+}
+
+export interface NftWeightRecord {
+  account: {
+    nft_owner: PublicKey
+    weight: BN
   }
   publicKey: PublicKey
 }
@@ -24,6 +33,14 @@ export const getUsedNftsForProposal = async (
     ]
   )) as NftVoteRecord[]
   return nftVoteRecordsFiltered
+}
+
+export const getUsedNftWeightRecordsForUser = async (
+  client: NftVoterClient
+  //walletPk: PublicKey
+) => {
+  const nftWeightRecordsFiltered = ((await client.program.account.nftWeightRecord.all()) as unknown) as NftWeightRecord[]
+  return nftWeightRecordsFiltered
 }
 
 export const getNftVoteRecordProgramAddress = async (
@@ -50,11 +67,16 @@ export const getNftWeightRecordProgramAddress = async (
   nftMintAddress: string,
   clientProgramId: PublicKey
 ) => {
-  const [nftWeightRecord, nftWeightRecordBump] =
-    await PublicKey.findProgramAddress(
-      [Buffer.from('nft-weight-record'), new PublicKey(nftMintAddress).toBuffer()],
-      clientProgramId
-    )
+  const [
+    nftWeightRecord,
+    nftWeightRecordBump,
+  ] = await PublicKey.findProgramAddress(
+    [
+      Buffer.from('nft-weight-record'),
+      new PublicKey(nftMintAddress).toBuffer(),
+    ],
+    clientProgramId
+  )
 
   return {
     nftWeightRecord,

--- a/NftVotePlugin/accounts.ts
+++ b/NftVotePlugin/accounts.ts
@@ -43,7 +43,7 @@ export const getUsedNftWeightRecordsForOwner = async (
     [
       {
         memcmp: {
-          offset: 8,
+          offset: 0,
           bytes: owner.toBase58(),
         },
       },
@@ -83,8 +83,8 @@ export const getNftWeightRecordProgramAddress = async (
   ] = await PublicKey.findProgramAddress(
     [
       Buffer.from('nft-weight-record'),
-      owner.toBuffer(),
       new PublicKey(nftMintAddress).toBuffer(),
+      owner.toBuffer(),
     ],
     clientProgramId
   )

--- a/NftVotePlugin/accounts.ts
+++ b/NftVotePlugin/accounts.ts
@@ -10,7 +10,7 @@ export interface NftVoteRecord {
   publicKey: PublicKey
 }
 
-export interface NftWeightRecord {
+export interface NftVoteTicket {
   account: {
     nft_owner: PublicKey
     weight: BN
@@ -35,21 +35,21 @@ export const getUsedNftsForProposal = async (
   return nftVoteRecordsFiltered
 }
 
-export const getUsedNftWeightRecordsForOwner = async (
+export const getVoterNftVoteTicketsForRegistrar = async (
   client: NftVoterClient,
-  owner: PublicKey
+  registrar: PublicKey
 ) => {
-  const nftWeightRecordsFiltered = ((await client.program.account.nftWeightRecord.all(
+  const nftVoteTicketsFiltered = ((await client.program.account.nftVoteTicket.all(
     [
       {
         memcmp: {
           offset: 8,
-          bytes: owner.toBase58(),
+          bytes: registrar.toBase58(),
         },
       },
     ]
-  )) as unknown) as NftWeightRecord[]
-  return nftWeightRecordsFiltered
+  )) as unknown) as NftVoteTicket[]
+  return nftVoteTicketsFiltered
 }
 
 export const getNftVoteRecordProgramAddress = async (
@@ -72,25 +72,22 @@ export const getNftVoteRecordProgramAddress = async (
   }
 }
 
-export const getNftWeightRecordProgramAddress = async (
+export const getNftVoteTicketProgramAddress = async (
   nftMintAddress: string,
-  owner: PublicKey,
+  registrar: PublicKey,
   clientProgramId: PublicKey
 ) => {
-  const [
-    nftWeightRecord,
-    nftWeightRecordBump,
-  ] = await PublicKey.findProgramAddress(
+  const [nftVoteTicket, nftVoteTicketBump] = await PublicKey.findProgramAddress(
     [
       Buffer.from('nft-weight-record'),
-      owner.toBuffer(),
+      registrar.toBuffer(),
       new PublicKey(nftMintAddress).toBuffer(),
     ],
     clientProgramId
   )
 
   return {
-    nftWeightRecord,
-    nftWeightRecordBump,
+    nftVoteTicket,
+    nftVoteTicketBump,
   }
 }

--- a/actions/castVote.ts
+++ b/actions/castVote.ts
@@ -56,7 +56,8 @@ export async function castVote(
 ) {
   const signers: Keypair[] = []
   const instructions: TransactionInstruction[] = []
-  const createNftVoteTicketIxs: TransactionInstruction[] = []
+  const createNftCastVoteTicketIxs: TransactionInstruction[] = []
+  const createNftMessageTicketIxs: TransactionInstruction[] = []
 
   const governanceAuthority = walletPubkey
   const payer = walletPubkey
@@ -72,7 +73,7 @@ export async function castVote(
     instructions,
     proposal,
     tokenOwnerRecord,
-    createNftVoteTicketIxs
+    createNftCastVoteTicketIxs
   )
 
   // It is not clear that defining these extraneous fields, `deny` and `veto`, is actually necessary.
@@ -132,7 +133,9 @@ export async function castVote(
     const plugin = await votingPlugin?.withUpdateVoterWeightRecord(
       instructions,
       tokenOwnerRecord,
-      'commentProposal'
+      'commentProposal',
+      undefined,
+      createNftMessageTicketIxs
     )
 
     await withPostChatMessage(
@@ -227,9 +230,12 @@ export async function castVote(
       instructions.length - ixChunkCount
     )
 
-    const createNftVoteTicketsChunks = chunks(createNftVoteTicketIxs, 1)
-    const splIxsWithAccountsChunk = chunks(ixsWithOwnChunk, 2)
+    const createNftVoteTicketsChunks = chunks(
+      [...createNftCastVoteTicketIxs, ...createNftMessageTicketIxs],
+      1
+    )
     const nftsAccountsChunks = chunks(remainingIxsToChunk, 2)
+    const splIxsWithAccountsChunk = chunks(ixsWithOwnChunk, 2)
 
     const instructionsChunks = [
       ...createNftVoteTicketsChunks.map((txBatch, batchIdx) => {

--- a/actions/castVote.ts
+++ b/actions/castVote.ts
@@ -230,11 +230,7 @@ export async function castVote(
     const createNftWeightRecordsChunks = chunks(createNftWeightRecordIxs, 1)
     const splIxsWithAccountsChunk = chunks(ixsWithOwnChunk, 2)
     const nftsAccountsChunks = chunks(remainingIxsToChunk, 2)
-    console.log(
-      createNftWeightRecordsChunks,
-      splIxsWithAccountsChunk,
-      nftsAccountsChunks
-    )
+
     const instructionsChunks = [
       ...createNftWeightRecordsChunks.map((txBatch, batchIdx) => {
         return {

--- a/actions/castVote.ts
+++ b/actions/castVote.ts
@@ -56,7 +56,7 @@ export async function castVote(
 ) {
   const signers: Keypair[] = []
   const instructions: TransactionInstruction[] = []
-  const createNftWeightRecordIxs: TransactionInstruction[] = []
+  const createNftVoteTicketIxs: TransactionInstruction[] = []
 
   const governanceAuthority = walletPubkey
   const payer = walletPubkey
@@ -72,7 +72,7 @@ export async function castVote(
     instructions,
     proposal,
     tokenOwnerRecord,
-    createNftWeightRecordIxs
+    createNftVoteTicketIxs
   )
 
   // It is not clear that defining these extraneous fields, `deny` and `veto`, is actually necessary.
@@ -227,12 +227,12 @@ export async function castVote(
       instructions.length - ixChunkCount
     )
 
-    const createNftWeightRecordsChunks = chunks(createNftWeightRecordIxs, 1)
+    const createNftVoteTicketsChunks = chunks(createNftVoteTicketIxs, 1)
     const splIxsWithAccountsChunk = chunks(ixsWithOwnChunk, 2)
     const nftsAccountsChunks = chunks(remainingIxsToChunk, 2)
 
     const instructionsChunks = [
-      ...createNftWeightRecordsChunks.map((txBatch, batchIdx) => {
+      ...createNftVoteTicketsChunks.map((txBatch, batchIdx) => {
         return {
           instructionsSet: txBatchesToInstructionSetWithSigners(
             txBatch,

--- a/actions/castVote.ts
+++ b/actions/castVote.ts
@@ -250,6 +250,7 @@ export async function castVote(
             batchIdx
           ),
           sequenceType:
+            // this is to ensure create all the nft_weight_records account first
             batchIdx === 0 ? SequenceType.Sequential : SequenceType.Parallel,
         }
       }),

--- a/actions/createProposal.ts
+++ b/actions/createProposal.ts
@@ -73,6 +73,7 @@ export const createProposal = async (
   callbacks?: Parameters<typeof sendTransactionsV3>[0]['callbacks']
 ): Promise<PublicKey> => {
   const instructions: TransactionInstruction[] = []
+  const createNftProposalTicketIxs: TransactionInstruction[] = []
   const governanceAuthority = walletPubkey
   const signatory = walletPubkey
   const payer = walletPubkey
@@ -100,7 +101,8 @@ export const createProposal = async (
     instructions,
     tokenOwnerRecord,
     'createProposal',
-    governance
+    governance,
+    createNftProposalTicketIxs
   )
 
   const proposalAddress = await withCreateProposal(
@@ -238,17 +240,10 @@ export const createProposal = async (
 
   if (isNftVoter) {
     // update voter weight records
-    const ixChunkCount = 3
-    const createNftWeightRecordIxs = instructions.slice(
-      0,
-      instructions.length - ixChunkCount
-    )
-    const nftWeightRecordAccountsChuncks = chunks(createNftWeightRecordIxs, 1)
-
-    const remainingIxs = instructions.slice(-ixChunkCount)
+    const nftWeightRecordAccountsChuncks = chunks(createNftProposalTicketIxs, 1)
     const splIxsWithAccountsChunk = [
       ...chunks(deduplicatedPrerequisiteInstructions, lowestChunkBy),
-      remainingIxs,
+      instructions,
       ...insertChunks,
     ]
 

--- a/constants/plugins.ts
+++ b/constants/plugins.ts
@@ -18,7 +18,8 @@ export const HELIUM_VSR_PLUGINS_PKS: string[] = [
 export const NFT_PLUGINS_PKS: string[] = [
   DEFAULT_NFT_VOTER_PLUGIN,
   'GnftV5kLjd67tvHpNGyodwWveEKivz3ZWvvE3Z4xi2iw',
-  'GnftVc21v2BRchsRa9dGdrVmJPLZiRHe9j2offnFTZFg',
+  'GnftVc21v2BRchsRa9dGdrVmJPLZiRHe9j2offnFTZFg', // support nft and cnft(version: verification and vote actions are in same instruction)
+  'GnFtjPodvrUFr2UYVFPUZUE6sMVoMWEJazd6NZZDkAXd', //support nft and cnft(version: verification and vote actions are splited to different instruction)
 ]
 
 export const GATEWAY_PLUGINS_PKS: string[] = [

--- a/idls/nft_voter.ts
+++ b/idls/nft_voter.ts
@@ -163,7 +163,7 @@ export type NftVoter = {
       "args": []
     },
     {
-      "name": "updateNftVoterWeightRecord",
+      "name": "updateVoterWeightRecord",
       "accounts": [
         {
           "name": "registrar",
@@ -177,39 +177,11 @@ export type NftVoter = {
           "name": "voterWeightRecord",
           "isMut": true,
           "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "voterWeightAction",
-          "type": {
-            "defined": "VoterWeightAction"
-          }
-        }
-      ]
-    },
-    {
-      "name": "updateCnftVoterWeightRecord",
-      "accounts": [
-        {
-          "name": "registrar",
-          "isMut": false,
-          "isSigner": false
         },
         {
-          "name": "voterWeightRecord",
+          "name": "payer",
           "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "leafOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "compressionProgram",
-          "isMut": false,
-          "isSigner": false
+          "isSigner": true
         }
       ],
       "args": [
@@ -217,14 +189,6 @@ export type NftVoter = {
           "name": "voterWeightAction",
           "type": {
             "defined": "VoterWeightAction"
-          }
-        },
-        {
-          "name": "params",
-          "type": {
-            "vec": {
-              "defined": "CompressedNftAsset"
-            }
           }
         }
       ]
@@ -360,7 +324,8 @@ export type NftVoter = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "TokenOwnerRecord of the voter who casts the vote"
+            "TokenOwnerRecord of the voter who casts the vote",
+            "/// CHECK: Owned by spl-governance instance specified in registrar.governance_program_id"
           ]
         },
         {
@@ -394,7 +359,7 @@ export type NftVoter = {
       ]
     },
     {
-      "name": "castCompressedNftVote",
+      "name": "createNftWeightRecord",
       "accounts": [
         {
           "name": "registrar",
@@ -407,8 +372,34 @@ export type NftVoter = {
           "isSigner": false
         },
         {
-          "name": "voterTokenOwnerRecord",
+          "name": "voterAuthority",
           "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "createCnftWeightRecord",
+      "accounts": [
+        {
+          "name": "registrar",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "voterWeightRecord",
+          "isMut": true,
           "isSigner": false
         },
         {
@@ -439,43 +430,11 @@ export type NftVoter = {
       ],
       "args": [
         {
-          "name": "proposal",
-          "type": "publicKey"
-        },
-        {
           "name": "params",
           "type": {
             "vec": {
               "defined": "CompressedNftAsset"
             }
-          }
-        }
-      ]
-    },
-    {
-      "name": "verifyCnftMetadata",
-      "accounts": [
-        {
-          "name": "leafOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "payer",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "compressionProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "CompressedNftAsset"
           }
         }
       ]
@@ -512,6 +471,22 @@ export type NftVoter = {
               "It's a Realm member pubkey corresponding to TokenOwnerRecord.governing_token_owner"
             ],
             "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "nftWeightRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "nftOwner",
+            "type": "publicKey"
+          },
+          {
+            "name": "weight",
+            "type": "u64"
           }
         ]
       }
@@ -1090,6 +1065,21 @@ export type NftVoter = {
       "code": 6032,
       "name": "LeafOwnerMustBeVoterAuthority",
       "msg": "Leaf Owner Must Be Voter Authority"
+    },
+    {
+      "code": 6033,
+      "name": "AccountDataNotEmpty",
+      "msg": "Account Data Not Empty"
+    },
+    {
+      "code": 6034,
+      "name": "NftFailedVerification",
+      "msg": "NFT Failed Verification"
+    },
+    {
+      "code": 6035,
+      "name": "InvalidPdaOwner",
+      "msg": "Invalid PDA Owner"
     }
   ]
 };
@@ -1259,7 +1249,7 @@ export const IDL: NftVoter = {
       "args": []
     },
     {
-      "name": "updateNftVoterWeightRecord",
+      "name": "updateVoterWeightRecord",
       "accounts": [
         {
           "name": "registrar",
@@ -1273,39 +1263,11 @@ export const IDL: NftVoter = {
           "name": "voterWeightRecord",
           "isMut": true,
           "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "voterWeightAction",
-          "type": {
-            "defined": "VoterWeightAction"
-          }
-        }
-      ]
-    },
-    {
-      "name": "updateCnftVoterWeightRecord",
-      "accounts": [
-        {
-          "name": "registrar",
-          "isMut": false,
-          "isSigner": false
         },
         {
-          "name": "voterWeightRecord",
+          "name": "payer",
           "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "leafOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "compressionProgram",
-          "isMut": false,
-          "isSigner": false
+          "isSigner": true
         }
       ],
       "args": [
@@ -1313,14 +1275,6 @@ export const IDL: NftVoter = {
           "name": "voterWeightAction",
           "type": {
             "defined": "VoterWeightAction"
-          }
-        },
-        {
-          "name": "params",
-          "type": {
-            "vec": {
-              "defined": "CompressedNftAsset"
-            }
           }
         }
       ]
@@ -1456,7 +1410,8 @@ export const IDL: NftVoter = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "TokenOwnerRecord of the voter who casts the vote"
+            "TokenOwnerRecord of the voter who casts the vote",
+            "/// CHECK: Owned by spl-governance instance specified in registrar.governance_program_id"
           ]
         },
         {
@@ -1490,7 +1445,7 @@ export const IDL: NftVoter = {
       ]
     },
     {
-      "name": "castCompressedNftVote",
+      "name": "createNftWeightRecord",
       "accounts": [
         {
           "name": "registrar",
@@ -1503,8 +1458,34 @@ export const IDL: NftVoter = {
           "isSigner": false
         },
         {
-          "name": "voterTokenOwnerRecord",
+          "name": "voterAuthority",
           "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "createCnftWeightRecord",
+      "accounts": [
+        {
+          "name": "registrar",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "voterWeightRecord",
+          "isMut": true,
           "isSigner": false
         },
         {
@@ -1535,43 +1516,11 @@ export const IDL: NftVoter = {
       ],
       "args": [
         {
-          "name": "proposal",
-          "type": "publicKey"
-        },
-        {
           "name": "params",
           "type": {
             "vec": {
               "defined": "CompressedNftAsset"
             }
-          }
-        }
-      ]
-    },
-    {
-      "name": "verifyCnftMetadata",
-      "accounts": [
-        {
-          "name": "leafOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "payer",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "compressionProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "CompressedNftAsset"
           }
         }
       ]
@@ -1608,6 +1557,22 @@ export const IDL: NftVoter = {
               "It's a Realm member pubkey corresponding to TokenOwnerRecord.governing_token_owner"
             ],
             "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "nftWeightRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "nftOwner",
+            "type": "publicKey"
+          },
+          {
+            "name": "weight",
+            "type": "u64"
           }
         ]
       }
@@ -2186,6 +2151,21 @@ export const IDL: NftVoter = {
       "code": 6032,
       "name": "LeafOwnerMustBeVoterAuthority",
       "msg": "Leaf Owner Must Be Voter Authority"
+    },
+    {
+      "code": 6033,
+      "name": "AccountDataNotEmpty",
+      "msg": "Account Data Not Empty"
+    },
+    {
+      "code": 6034,
+      "name": "NftFailedVerification",
+      "msg": "NFT Failed Verification"
+    },
+    {
+      "code": 6035,
+      "name": "InvalidPdaOwner",
+      "msg": "Invalid PDA Owner"
     }
   ]
 };

--- a/idls/nft_voter.ts
+++ b/idls/nft_voter.ts
@@ -387,7 +387,14 @@ export type NftVoter = {
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "voterWeightAction",
+          "type": {
+            "defined": "VoterWeightAction"
+          }
+        }
+      ]
     },
     {
       "name": "createCnftVoteTicket",
@@ -429,6 +436,12 @@ export type NftVoter = {
         }
       ],
       "args": [
+        {
+          "name": "voterWeightAction",
+          "type": {
+            "defined": "VoterWeightAction"
+          }
+        },
         {
           "name": "params",
           "type": {
@@ -1473,7 +1486,14 @@ export const IDL: NftVoter = {
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "voterWeightAction",
+          "type": {
+            "defined": "VoterWeightAction"
+          }
+        }
+      ]
     },
     {
       "name": "createCnftVoteTicket",
@@ -1515,6 +1535,12 @@ export const IDL: NftVoter = {
         }
       ],
       "args": [
+        {
+          "name": "voterWeightAction",
+          "type": {
+            "defined": "VoterWeightAction"
+          }
+        },
         {
           "name": "params",
           "type": {

--- a/idls/nft_voter.ts
+++ b/idls/nft_voter.ts
@@ -359,7 +359,7 @@ export type NftVoter = {
       ]
     },
     {
-      "name": "createNftWeightRecord",
+      "name": "createNftVoteTicket",
       "accounts": [
         {
           "name": "registrar",
@@ -390,7 +390,7 @@ export type NftVoter = {
       "args": []
     },
     {
-      "name": "createCnftWeightRecord",
+      "name": "createCnftVoteTicket",
       "accounts": [
         {
           "name": "registrar",
@@ -476,7 +476,7 @@ export type NftVoter = {
       }
     },
     {
-      "name": "nftWeightRecord",
+      "name": "nftVoteTicket",
       "type": {
         "kind": "struct",
         "fields": [
@@ -1445,7 +1445,7 @@ export const IDL: NftVoter = {
       ]
     },
     {
-      "name": "createNftWeightRecord",
+      "name": "createNftVoteTicket",
       "accounts": [
         {
           "name": "registrar",
@@ -1476,7 +1476,7 @@ export const IDL: NftVoter = {
       "args": []
     },
     {
-      "name": "createCnftWeightRecord",
+      "name": "createCnftVoteTicket",
       "accounts": [
         {
           "name": "registrar",
@@ -1562,7 +1562,7 @@ export const IDL: NftVoter = {
       }
     },
     {
-      "name": "nftWeightRecord",
+      "name": "nftVoteTicket",
       "type": {
         "kind": "struct",
         "fields": [

--- a/tools/constants.ts
+++ b/tools/constants.ts
@@ -11,6 +11,6 @@ export const DISABLED_VALUE = new BN('18446744073709551615')
 // Note: when running a local validator ensure the account is copied from devnet: --clone ENmcpFCpxN1CqyUjuog9yyUVfdXBKF3LVCwLr7grJZpk -ud
 export const SIMULATION_WALLET = 'ENmcpFCpxN1CqyUjuog9yyUVfdXBKF3LVCwLr7grJZpk'
 
-export const DEFAULT_NFT_VOTER_PLUGIN =
-  'GnftVc21v2BRchsRa9dGdrVmJPLZiRHe9j2offnFTZFg'
-// 'GnftV5kLjd67tvHpNGyodwWveEKivz3ZWvvE3Z4xi2iw' old nft voter
+export const DEFAULT_NFT_VOTER_PLUGIN = 'GnFtjPodvrUFr2UYVFPUZUE6sMVoMWEJazd6NZZDkAXd' // verify and action different instruction
+ // 'GnftVc21v2BRchsRa9dGdrVmJPLZiRHe9j2offnFTZFg' // verify and action same instruction
+// 'GnftV5kLjd67tvHpNGyodwWveEKivz3ZWvvE3Z4xi2iw' //old nft voter

--- a/utils/uiTypes/VotePlugin.ts
+++ b/utils/uiTypes/VotePlugin.ts
@@ -33,7 +33,7 @@ import { VsrClient } from 'VoteStakeRegistry/sdk/client'
 import {
   getNftVoteRecordProgramAddress,
   getNftWeightRecordProgramAddress,
-  getUsedNftWeightRecordsForUser,
+  getUsedNftWeightRecordsForOwner,
   getUsedNftsForProposal,
 } from 'NftVotePlugin/accounts'
 import { PositionWithMeta } from 'HeliumVotePlugin/sdk/types'
@@ -282,8 +282,9 @@ export class VotingClient {
       )
 
       /// this should add walletPk to the list of oracles
-      const nftWeightRecordsFiltered = await getUsedNftWeightRecordsForUser(
-        this.client
+      const nftWeightRecordsFiltered = await getUsedNftWeightRecordsForOwner(
+        this.client,
+        walletPk
       )
 
       // udpate voter weight record can upmost encapsulate 10 nfts
@@ -295,6 +296,7 @@ export class VotingClient {
       for (const nft of nfts) {
         const { nftWeightRecord } = await getNftWeightRecordProgramAddress(
           nft.id,
+          walletPk,
           clientProgramId
         )
         if (
@@ -346,6 +348,7 @@ export class VotingClient {
       for (const cnft of compressedNfts) {
         const { nftWeightRecord } = await getNftWeightRecordProgramAddress(
           cnft.id,
+          walletPk,
           clientProgramId
         )
         if (
@@ -599,8 +602,9 @@ export class VotingClient {
         this.client,
         proposal.pubkey
       )
-      const nftWeightRecordsFiltered = await getUsedNftWeightRecordsForUser(
-        this.client
+      const nftWeightRecordsFiltered = await getUsedNftWeightRecordsForOwner(
+        this.client,
+        walletPk
       )
       const castVoteRemainingAccounts: AccountData[] = []
 
@@ -620,6 +624,7 @@ export class VotingClient {
         ) {
           const { nftWeightRecord } = await getNftWeightRecordProgramAddress(
             nft.id,
+            walletPk,
             clientProgramId
           )
 
@@ -684,6 +689,7 @@ export class VotingClient {
         ) {
           const { nftWeightRecord } = await getNftWeightRecordProgramAddress(
             cnft.id,
+            walletPk,
             clientProgramId
           )
 


### PR DESCRIPTION
integrate with the new version of nft-voter.
Big changes
1. VoterPlugin.ts: for both `withUpdateVoterWeightRecord()` and `withCastNftVote()`, we create the nft tickets first for every nft fo the corresponding action.
2. castVote.ts: change the parallel and sequential transaction sending process to match the new voting process, where the steps are: create tickets for voting -> nft-voter cast vote -> governance cast vote -> create tickets for comment -> write comments to proposal.